### PR TITLE
Remove For Update Lock Statement

### DIFF
--- a/src/Cockroach/Grammar/Query/CockroachGrammar.php
+++ b/src/Cockroach/Grammar/Query/CockroachGrammar.php
@@ -52,6 +52,8 @@ class CockroachGrammar extends Grammar
 
     /**
      * Compile the lock into SQL.
+     * Cockroach DB Doesn't support For Update / For Share Locks. 
+     * Thus this function always returns a empty string as of now. 
      *
      * @param  \Illuminate\Database\Query\Builder  $query
      * @param  bool|string  $value
@@ -59,11 +61,12 @@ class CockroachGrammar extends Grammar
      */
     protected function compileLock(Builder $query, $value)
     {
-        if (! is_string($value)) {
-            return $value ? 'for update' : 'for share';
-        }
+        //if (! is_string($value)) {
+        //    return $value ? 'for update' : 'for share';
+        //}
 
-        return $value;
+        //return $value;
+        return '';
     }
 
     /**


### PR DESCRIPTION
The above statement creates collisions in CockroachDB. 

CockroachDB doesn't support "for update" statements yet, and the select queries have such functionality automatically in the engine. 

See here for the issue. cockroachdb/cockroach#6583